### PR TITLE
Issue #2: Add New Endpoint for Historical Prices

### DIFF
--- a/src/main/java/org/galatea/starter/domain/IexHistoricalPrice.java
+++ b/src/main/java/org/galatea/starter/domain/IexHistoricalPrice.java
@@ -1,0 +1,17 @@
+package org.galatea.starter.domain;
+
+import java.math.BigDecimal;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class IexHistoricalPrice {
+  private BigDecimal close;
+  private BigDecimal high;
+  private BigDecimal low;
+  private BigDecimal open;
+  private String symbol;
+  private Integer volume;
+  private String date;
+}

--- a/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
+++ b/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.sf.aspect4log.Log;
 import net.sf.aspect4log.Log.Level;
+import org.galatea.starter.domain.IexHistoricalPrice;
 import org.galatea.starter.domain.IexLastTradedPrice;
 import org.galatea.starter.domain.IexSymbol;
 import org.galatea.starter.service.IexService;
@@ -48,4 +49,20 @@ public class IexRestController {
     return iexService.getLastTradedPriceForSymbols(symbols);
   }
 
+  /**
+   * Get the historical price for each of the symbols passed in.
+   *
+   * @param symbol list of symbols to get the historical price for.
+   * @param date list of days to get the historical price for.
+   * @param range range of time from the specified date to get data for.
+   * @return a list of daily prices for date and range specified for the particular symbol.
+   */
+  @GetMapping(value = "${mvc.iex.getHistoricalPricePath}", produces = {
+      MediaType.APPLICATION_JSON_VALUE})
+  public List<IexHistoricalPrice> getHistoricalPrices(
+      @RequestParam(value = "symbol") final String symbol,
+      @RequestParam(value = "range", required = false) final String range,
+      @RequestParam(value = "date", required = false) final String date) {
+    return iexService.getHistoricalPrices(symbol, range, date);
+  }
 }

--- a/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
+++ b/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
@@ -1,6 +1,7 @@
 package org.galatea.starter.entrypoint;
 
 import java.util.List;
+import javax.validation.constraints.NotBlank;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -60,7 +61,7 @@ public class IexRestController {
   @GetMapping(value = "${mvc.iex.getHistoricalPricePath}", produces = {
       MediaType.APPLICATION_JSON_VALUE})
   public List<IexHistoricalPrice> getHistoricalPrices(
-      @RequestParam(value = "symbol") final String symbol,
+      @RequestParam(value = "symbol") @NotBlank final String symbol,
       @RequestParam(value = "range", required = false) final String range,
       @RequestParam(value = "date", required = false) final String date) {
     return iexService.getHistoricalPrices(symbol, range, date);

--- a/src/main/java/org/galatea/starter/entrypoint/RestExceptionHandler.java
+++ b/src/main/java/org/galatea/starter/entrypoint/RestExceptionHandler.java
@@ -1,6 +1,7 @@
 package org.galatea.starter.entrypoint;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import feign.FeignException;
 import javax.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.galatea.starter.entrypoint.exception.EntityNotFoundException;
@@ -73,8 +74,18 @@ public class RestExceptionHandler {
     return buildResponseEntity(error);
   }
 
+  @ExceptionHandler(FeignException.class)
+  protected ResponseEntity<Object> handleFeignStatusException(final FeignException exception) {
+    log.debug("Error connecting to IEX", exception);
+
+    ApiError error = new ApiError(HttpStatus.INTERNAL_SERVER_ERROR, exception.toString());
+    return buildResponseEntity(error);
+  }
+
   private ResponseEntity<Object> buildResponseEntity(final ApiError apiError) {
     return new ResponseEntity<>(apiError, apiError.getStatus());
   }
+
+
 
 }

--- a/src/main/java/org/galatea/starter/entrypoint/RestExceptionHandler.java
+++ b/src/main/java/org/galatea/starter/entrypoint/RestExceptionHandler.java
@@ -76,7 +76,7 @@ public class RestExceptionHandler {
 
   @ExceptionHandler(FeignException.class)
   protected ResponseEntity<Object> handleFeignStatusException(final FeignException exception) {
-    log.debug("Error connecting to IEX", exception);
+    log.error("Error connecting to IEX", exception);
 
     ApiError error = new ApiError(HttpStatus.INTERNAL_SERVER_ERROR, exception.toString());
     return buildResponseEntity(error);

--- a/src/main/java/org/galatea/starter/service/IexClient.java
+++ b/src/main/java/org/galatea/starter/service/IexClient.java
@@ -1,6 +1,7 @@
 package org.galatea.starter.service;
 
 import java.util.List;
+import org.galatea.starter.domain.IexHistoricalPrice;
 import org.galatea.starter.domain.IexLastTradedPrice;
 import org.galatea.starter.domain.IexSymbol;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -31,5 +32,4 @@ public interface IexClient {
    */
   @GetMapping("/tops/last")
   List<IexLastTradedPrice> getLastTradedPriceForSymbols(@RequestParam("symbols") String[] symbols);
-
 }

--- a/src/main/java/org/galatea/starter/service/IexClient.java
+++ b/src/main/java/org/galatea/starter/service/IexClient.java
@@ -1,7 +1,6 @@
 package org.galatea.starter.service;
 
 import java.util.List;
-import org.galatea.starter.domain.IexHistoricalPrice;
 import org.galatea.starter.domain.IexLastTradedPrice;
 import org.galatea.starter.domain.IexSymbol;
 import org.springframework.cloud.openfeign.FeignClient;

--- a/src/main/java/org/galatea/starter/service/IexCloudClient.java
+++ b/src/main/java/org/galatea/starter/service/IexCloudClient.java
@@ -5,7 +5,6 @@ import org.galatea.starter.domain.IexHistoricalPrice;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 
 /**
  * A Feign Declarative REST Client to access endpoints from the Cloud IEX API to get market

--- a/src/main/java/org/galatea/starter/service/IexCloudClient.java
+++ b/src/main/java/org/galatea/starter/service/IexCloudClient.java
@@ -1,0 +1,70 @@
+package org.galatea.starter.service;
+
+import java.util.List;
+import org.galatea.starter.domain.IexHistoricalPrice;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * A Feign Declarative REST Client to access endpoints from the Cloud IEX API to get market
+ * data. See https://iexcloud.io/docs/api/
+ */
+@FeignClient(name = "IEXCloud", url = "${spring.rest.iexCloudPath}")
+public interface IexCloudClient {
+
+  /**
+   * Get the historical price data for the symbol passed in.
+   * See https://iexcloud.io/docs/api/#historical-prices.
+   *
+   * @param symbol stock symbols to historical prices for.
+   * @return a list of daily IexHistoricalPrices for the past month for the symbol specified.
+   */
+  @GetMapping("/stock/{symbol}/chart?token=${spring.rest.iexToken}")
+  List<IexHistoricalPrice> getHistoricalPricesSymbol(
+      @PathVariable(value = "symbol") String symbol);
+
+  /**
+   * Get the historical price data for each symbol passed in for each date and range passed in.
+   * See https://iexcloud.io/docs/api/#historical-prices.
+   *
+   * @param symbol stock symbols to historical price for.
+   * @param date date to get the historical data for
+   * @return a list containing a IexHistoricalPrice for the specified date.
+   */
+  @GetMapping("/stock/{symbol}/chart/date/{date}?chartByDate=true&token=${spring.rest.iexToken}")
+  List<IexHistoricalPrice> getHistoricalPricesDate(
+      @PathVariable(value = "symbol") String symbol,
+      @PathVariable(value = "date") String date);
+
+  /**
+   * Get the historical price data for each symbol passed in for each date and range passed in.
+   * See https://iexcloud.io/docs/api/#historical-prices.
+   *
+   * @param symbol stock symbols to historical prices for.
+   * @param range range of dates from date to get historical prices for.
+   * @return a list of IexHistoricalPrice for the symbol for the specified range.
+   */
+  @GetMapping("/stock/{symbol}/chart/{range}?token=${spring.rest.iexToken}")
+  List<IexHistoricalPrice> getHistoricalPricesRange(
+      @PathVariable(value = "symbol") String symbol,
+      @PathVariable(value = "range") String range);
+
+  /**
+   * Get the historical price data for each symbol passed in for each date and range passed in.
+   * See https://iexcloud.io/docs/api/#historical-prices.
+   * Note: if date is specified it will nullify the range input and will only return
+   * the price of the exact day.
+   *
+   * @param symbol stock symbols to historical prices for.
+   * @param date date to begin getting historical prices for.
+   * @param range range of dates from date to get historical prices for.
+   * @return a list of IexHistoricalPrice for the specified date and symbol.
+   */
+  @GetMapping("/stock/{symbol}/chart/{range}/{date}?chartByDay=true&token=${spring.rest.iexToken}")
+  List<IexHistoricalPrice> getHistoricalPrices(
+      @PathVariable(value = "symbol") String symbol,
+      @PathVariable(value = "range") String range,
+      @PathVariable(value = "date") String date);
+}

--- a/src/main/java/org/galatea/starter/service/IexService.java
+++ b/src/main/java/org/galatea/starter/service/IexService.java
@@ -58,9 +58,7 @@ public class IexService {
       final String symbol,
       final String range,
       final String date) {
-    if (symbol.isEmpty()) {
-      return Collections.emptyList();
-    } else if (date == null && range == null){
+    if (date == null && range == null) {
       return iexCloudClient.getHistoricalPricesSymbol(symbol);
     } else if (range == null) {
       return iexCloudClient.getHistoricalPricesDate(symbol, date);

--- a/src/main/java/org/galatea/starter/service/IexService.java
+++ b/src/main/java/org/galatea/starter/service/IexService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.galatea.starter.domain.IexHistoricalPrice;
 import org.galatea.starter.domain.IexLastTradedPrice;
 import org.galatea.starter.domain.IexSymbol;
 import org.springframework.stereotype.Service;
@@ -20,7 +21,8 @@ public class IexService {
 
   @NonNull
   private IexClient iexClient;
-
+  @NonNull
+  private IexCloudClient iexCloudClient;
 
   /**
    * Get all stock symbols from IEX.
@@ -45,5 +47,27 @@ public class IexService {
     }
   }
 
-
+  /**
+   * Get the historical price for a specified Symbol for a certain range starting at date.
+   * @param symbol the symbol to get historical prices for.
+   * @param date the date to begin getting historical prices at.
+   * @param range the range to get historical prices at.
+   * @return a list of historical prices for the specified symbol and time frame.
+   */
+  public List<IexHistoricalPrice> getHistoricalPrices(
+      final String symbol,
+      final String range,
+      final String date) {
+    if (symbol.isEmpty()) {
+      return Collections.emptyList();
+    } else if (date == null && range == null){
+      return iexCloudClient.getHistoricalPricesSymbol(symbol);
+    } else if (range == null) {
+      return iexCloudClient.getHistoricalPricesDate(symbol, date);
+    } else if (date == null) {
+      return iexCloudClient.getHistoricalPricesRange(symbol, range);
+    } else {
+      return iexCloudClient.getHistoricalPrices(symbol, range, date);
+    }
+  }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,7 @@ mvc:
    iex:
       getAllSymbolsPath: /iex/symbols
       getLastTradedPricePath: /iex/lastTradedPrice
+      getHistoricalPricePath: /iex/historicalPrice
    max-size-trace-payload: 50000
 jms:
    listener-concurrency: 1-5
@@ -47,6 +48,8 @@ spring:
    rest:
       # this points at the local WireMock server in the test environment.
       iexBasePath: http://localhost:${wiremock.server.port}/
+      iexCloudPath: http://localhost:${wiremock.server.port}/
+      iexToken: TESTKEY
 
 ---
 # Dev properties go here
@@ -57,6 +60,9 @@ spring:
       password:
    rest:
       iexBasePath: https://api.iextrading.com/1.0
+      iexCloudPath: https://cloud.iexapis.com/stable
+      iexToken: IEX_KEY_HERE
+
 # set debug to get spring to log the classpath (and other things) on startup
 debug: true
 

--- a/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
@@ -165,4 +165,15 @@ public class IexRestControllerTest extends ASpringTest {
         .andExpect(status().isBadRequest())
         .andReturn();
   }
+
+  @Test
+  public void testGetHistoricalPriceFail() throws Exception {
+
+    MvcResult result = this.mvc.perform(
+        MockMvcRequestBuilders
+            .get("/iex/historicalPrice?symbol=twtrF")
+            .accept(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().is5xxServerError())
+        .andReturn();
+  }
 }

--- a/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 
 @RequiredArgsConstructor
@@ -45,7 +46,7 @@ public class IexRestControllerTest extends ASpringTest {
     MvcResult result = this.mvc.perform(
         // note that we were are testing the fuse REST end point here, not the IEX end point.
         // the fuse end point in turn calls the IEX end point, which is WireMocked for this test.
-        org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/iex/symbols")
+        MockMvcRequestBuilders.get("/iex/symbols")
             .accept(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isOk())
         // some simple validations, in practice I would expect these to be much more comprehensive.
@@ -59,7 +60,7 @@ public class IexRestControllerTest extends ASpringTest {
   public void testGetLastTradedPrice() throws Exception {
 
     MvcResult result = this.mvc.perform(
-        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+        MockMvcRequestBuilders
             .get("/iex/lastTradedPrice?symbols=AAPL")
             // This URL will be hit by the MockMvc client. The result is configured in the file
             // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
@@ -74,7 +75,7 @@ public class IexRestControllerTest extends ASpringTest {
   public void testGetLastTradedPriceEmpty() throws Exception {
 
     MvcResult result = this.mvc.perform(
-        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+        MockMvcRequestBuilders
             .get("/iex/lastTradedPrice?symbols=")
             .accept(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isOk())
@@ -86,7 +87,7 @@ public class IexRestControllerTest extends ASpringTest {
   public void testGetHistoricalPriceSymbol() throws Exception {
 
     MvcResult result = this.mvc.perform(
-        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+        MockMvcRequestBuilders
           .get("/iex/historicalPrice?symbol=twtr")
           .accept(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isOk())
@@ -104,7 +105,7 @@ public class IexRestControllerTest extends ASpringTest {
   public void testGetHistoricalPriceSymbolDate() throws Exception {
 
     MvcResult result = this.mvc.perform(
-        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+        MockMvcRequestBuilders
             .get("/iex/historicalPrice?symbol=twtr&date=20210405")
             .accept(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isOk())
@@ -122,7 +123,7 @@ public class IexRestControllerTest extends ASpringTest {
   public void testGetHistoricalPriceSymbolRange() throws Exception {
 
     MvcResult result = this.mvc.perform(
-        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+        MockMvcRequestBuilders
             .get("/iex/historicalPrice?symbol=twtr&range=3d")
             .accept(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isOk())
@@ -140,7 +141,7 @@ public class IexRestControllerTest extends ASpringTest {
   public void testGetHistoricalPriceSymbolRangeDate() throws Exception {
 
     MvcResult result = this.mvc.perform(
-        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+        MockMvcRequestBuilders
             .get("/iex/historicalPrice?symbol=twtr&range=1m&date=20210210")
             .accept(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isOk())
@@ -158,11 +159,10 @@ public class IexRestControllerTest extends ASpringTest {
   public void testGetHistoricalPriceEmpty() throws Exception {
 
     MvcResult result = this.mvc.perform(
-        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+        MockMvcRequestBuilders
             .get("/iex/historicalPrice?symbol=")
             .accept(MediaType.APPLICATION_JSON_VALUE))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$", is(Collections.emptyList())))
+        .andExpect(status().isBadRequest())
         .andReturn();
   }
 }

--- a/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
@@ -81,4 +81,88 @@ public class IexRestControllerTest extends ASpringTest {
         .andExpect(jsonPath("$", is(Collections.emptyList())))
         .andReturn();
   }
+
+  @Test
+  public void testGetHistoricalPriceSymbol() throws Exception {
+
+    MvcResult result = this.mvc.perform(
+        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+          .get("/iex/historicalPrice?symbol=twtr")
+          .accept(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].close").value(new BigDecimal("51.81")))
+        .andExpect(jsonPath("$[0].high").value(new BigDecimal("53.08")))
+        .andExpect(jsonPath("$[0].low").value(new BigDecimal("51.62")))
+        .andExpect(jsonPath("$[0].open").value(new BigDecimal("53.01")))
+        .andExpect(jsonPath("$[0].symbol", is("TWTR")))
+        .andExpect(jsonPath("$[0].volume").value(17362305))
+        .andExpect(jsonPath("$[0].date", is("2021-05-10")))
+        .andReturn();
+  }
+
+  @Test
+  public void testGetHistoricalPriceSymbolDate() throws Exception {
+
+    MvcResult result = this.mvc.perform(
+        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+            .get("/iex/historicalPrice?symbol=twtr&date=20210405")
+            .accept(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].close").value(new BigDecimal("64.24")))
+        .andExpect(jsonPath("$[0].high").value(new BigDecimal("64.34")))
+        .andExpect(jsonPath("$[0].low").value(new BigDecimal("61.81")))
+        .andExpect(jsonPath("$[0].open").value(new BigDecimal("64.14")))
+        .andExpect(jsonPath("$[0].symbol", is("TWTR")))
+        .andExpect(jsonPath("$[0].volume").value(15502130))
+        .andExpect(jsonPath("$[0].date", is("2021-04-05")))
+        .andReturn();
+  }
+
+  @Test
+  public void testGetHistoricalPriceSymbolRange() throws Exception {
+
+    MvcResult result = this.mvc.perform(
+        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+            .get("/iex/historicalPrice?symbol=twtr&range=3d")
+            .accept(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].close").value(new BigDecimal("57.01")))
+        .andExpect(jsonPath("$[0].high").value(new BigDecimal("58.67")))
+        .andExpect(jsonPath("$[0].low").value(new BigDecimal("55.83")))
+        .andExpect(jsonPath("$[0].open").value(new BigDecimal("56.96")))
+        .andExpect(jsonPath("$[0].symbol", is("TWTR")))
+        .andExpect(jsonPath("$[0].volume").value(21985673))
+        .andExpect(jsonPath("$[0].date", is("2021-06-03")))
+        .andReturn();
+  }
+
+  @Test
+  public void testGetHistoricalPriceSymbolRangeDate() throws Exception {
+
+    MvcResult result = this.mvc.perform(
+        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+            .get("/iex/historicalPrice?symbol=twtr&range=1m&date=20210210")
+            .accept(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].close").value(new BigDecimal("67.77")))
+        .andExpect(jsonPath("$[0].high").value(new BigDecimal("69.25")))
+        .andExpect(jsonPath("$[0].low").value(new BigDecimal("63.2")))
+        .andExpect(jsonPath("$[0].open").value(new BigDecimal("65.8")))
+        .andExpect(jsonPath("$[0].symbol", is("TWTR")))
+        .andExpect(jsonPath("$[0].volume").value(73649183))
+        .andExpect(jsonPath("$[0].date", is("2021-02-10")))
+        .andReturn();
+  }
+
+  @Test
+  public void testGetHistoricalPriceEmpty() throws Exception {
+
+    MvcResult result = this.mvc.perform(
+        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+            .get("/iex/historicalPrice?symbol=")
+            .accept(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", is(Collections.emptyList())))
+        .andReturn();
+  }
 }

--- a/src/test/resources/wiremock/mappings/mapping-historicalPriceFail.json
+++ b/src/test/resources/wiremock/mappings/mapping-historicalPriceFail.json
@@ -1,0 +1,31 @@
+{
+  "id": "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+  "name": "symbol_historical_price",
+  "request": {
+    "url": "/stock/twtrF/chart?token=TESTKEY",
+    "method": "GET"
+  },
+  "response": {
+    "status": 500,
+    "headers" : {
+      "Server" : "nginx",
+      "Date" : "Thu, 08 Aug 2019 14:08:53 GMT",
+      "Content-Type" : "application/json; charset=utf-8",
+      "Connection" : "keep-alive",
+      "set-cookie" : "ctoken=958c0e17a3f542a2a13ef676b670326d; Domain=.iextrading.com; Path=/; Expires=Fri, 09 Aug 2019 02:08:53 GMT; Secure",
+      "Content-Security-Policy" : "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+      "X-Content-Security-Policy" : "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+      "Frame-Options" : "SAMEORIGIN",
+      "X-Frame-Options" : "SAMEORIGIN",
+      "X-Content-Type-Options" : "nosniff",
+      "Strict-Transport-Security" : "max-age=15768000",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Credentials" : "true",
+      "Access-Control-Allow-Methods" : "GET, OPTIONS",
+      "Access-Control-Allow-Headers" : "Origin, X-Requested-With, Content-Type, Accept"
+    }
+  },
+  "uuid" : "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+  "persistent" : true,
+  "insertionIndex" : 5
+}

--- a/src/test/resources/wiremock/mappings/mapping-historicalPriceSymbolDate.json
+++ b/src/test/resources/wiremock/mappings/mapping-historicalPriceSymbolDate.json
@@ -1,0 +1,42 @@
+{
+  "id": "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+  "name": "symbol_date_historical_price",
+  "request": {
+    "url": "/stock/twtr/chart/date/20210405?chartByDate=true&token=TESTKEY",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": [
+      {
+        "close": 64.24,
+        "high": 64.34,
+        "low": 61.81,
+        "open": 64.14,
+        "symbol": "TWTR",
+        "volume": 15502130,
+        "date": "2021-04-05"
+      }
+    ],
+    "headers" : {
+      "Server" : "nginx",
+      "Date" : "Thu, 08 Aug 2019 14:08:53 GMT",
+      "Content-Type" : "application/json; charset=utf-8",
+      "Connection" : "keep-alive",
+      "set-cookie" : "ctoken=958c0e17a3f542a2a13ef676b670326d; Domain=.iextrading.com; Path=/; Expires=Fri, 09 Aug 2019 02:08:53 GMT; Secure",
+      "Content-Security-Policy" : "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+      "X-Content-Security-Policy" : "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+      "Frame-Options" : "SAMEORIGIN",
+      "X-Frame-Options" : "SAMEORIGIN",
+      "X-Content-Type-Options" : "nosniff",
+      "Strict-Transport-Security" : "max-age=15768000",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Credentials" : "true",
+      "Access-Control-Allow-Methods" : "GET, OPTIONS",
+      "Access-Control-Allow-Headers" : "Origin, X-Requested-With, Content-Type, Accept"
+    }
+  },
+  "uuid" : "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+  "persistent" : true,
+  "insertionIndex" : 5
+}

--- a/src/test/resources/wiremock/mappings/mapping-historicalPriceSymbolOnly.json
+++ b/src/test/resources/wiremock/mappings/mapping-historicalPriceSymbolOnly.json
@@ -1,0 +1,61 @@
+{
+  "id": "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+  "name": "symbol_historical_price",
+  "request": {
+    "url": "/stock/twtr/chart?token=TESTKEY",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": [
+      {
+        "close": 51.81,
+        "high": 53.08,
+        "low": 51.62,
+        "open": 53.01,
+        "symbol": "TWTR",
+        "volume": 17362305,
+        "id": "HISTORICAL_PRICES",
+        "key": "TWTR",
+        "subkey": "",
+        "date": "2021-05-10",
+        "updated": 1620694113000,
+        "changeOverTime": 0,
+        "marketChangeOverTime": 0,
+        "uOpen": 53.01,
+        "uClose": 51.81,
+        "uHigh": 53.08,
+        "uLow": 51.62,
+        "uVolume": 17362305,
+        "fOpen": 53.01,
+        "fClose": 51.81,
+        "fHigh": 53.08,
+        "fLow": 51.62,
+        "fVolume": 17362305,
+        "label": "May 10, 21",
+        "change": 0,
+        "changePercent": 0
+      }
+    ],
+    "headers" : {
+      "Server" : "nginx",
+      "Date" : "Thu, 08 Aug 2019 14:08:53 GMT",
+      "Content-Type" : "application/json; charset=utf-8",
+      "Connection" : "keep-alive",
+      "set-cookie" : "ctoken=958c0e17a3f542a2a13ef676b670326d; Domain=.iextrading.com; Path=/; Expires=Fri, 09 Aug 2019 02:08:53 GMT; Secure",
+      "Content-Security-Policy" : "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+      "X-Content-Security-Policy" : "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+      "Frame-Options" : "SAMEORIGIN",
+      "X-Frame-Options" : "SAMEORIGIN",
+      "X-Content-Type-Options" : "nosniff",
+      "Strict-Transport-Security" : "max-age=15768000",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Credentials" : "true",
+      "Access-Control-Allow-Methods" : "GET, OPTIONS",
+      "Access-Control-Allow-Headers" : "Origin, X-Requested-With, Content-Type, Accept"
+    }
+  },
+  "uuid" : "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+  "persistent" : true,
+  "insertionIndex" : 5
+}

--- a/src/test/resources/wiremock/mappings/mapping-historicalPriceSymbolRange.json
+++ b/src/test/resources/wiremock/mappings/mapping-historicalPriceSymbolRange.json
@@ -1,0 +1,61 @@
+{
+  "id": "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+  "name": "symbol_range_historical_price",
+  "request": {
+    "url": "/stock/twtr/chart/3d?token=TESTKEY",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": [
+      {
+        "close": 57.01,
+        "high": 58.67,
+        "low": 55.83,
+        "open": 56.96,
+        "symbol": "TWTR",
+        "volume": 21985673,
+        "id": "HISTORICAL_PRICES",
+        "key": "TWTR",
+        "subkey": "",
+        "date": "2021-06-03",
+        "updated": 1622768434000,
+        "changeOverTime": 0,
+        "marketChangeOverTime": 0,
+        "uOpen": 56.96,
+        "uClose": 57.01,
+        "uHigh": 58.67,
+        "uLow": 55.83,
+        "uVolume": 21985673,
+        "fOpen": 56.96,
+        "fClose": 57.01,
+        "fHigh": 58.67,
+        "fLow": 55.83,
+        "fVolume": 21985673,
+        "label": "Jun 3, 21",
+        "change": 0,
+        "changePercent": 0
+      }
+    ],
+    "headers" : {
+      "Server" : "nginx",
+      "Date" : "Thu, 08 Aug 2019 14:08:53 GMT",
+      "Content-Type" : "application/json; charset=utf-8",
+      "Connection" : "keep-alive",
+      "set-cookie" : "ctoken=958c0e17a3f542a2a13ef676b670326d; Domain=.iextrading.com; Path=/; Expires=Fri, 09 Aug 2019 02:08:53 GMT; Secure",
+      "Content-Security-Policy" : "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+      "X-Content-Security-Policy" : "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+      "Frame-Options" : "SAMEORIGIN",
+      "X-Frame-Options" : "SAMEORIGIN",
+      "X-Content-Type-Options" : "nosniff",
+      "Strict-Transport-Security" : "max-age=15768000",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Credentials" : "true",
+      "Access-Control-Allow-Methods" : "GET, OPTIONS",
+      "Access-Control-Allow-Headers" : "Origin, X-Requested-With, Content-Type, Accept"
+    }
+  },
+  "uuid" : "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+  "persistent" : true,
+  "insertionIndex" : 5
+}

--- a/src/test/resources/wiremock/mappings/mapping-historicalPriceSymbolRangeDate.json
+++ b/src/test/resources/wiremock/mappings/mapping-historicalPriceSymbolRangeDate.json
@@ -1,0 +1,61 @@
+{
+  "id": "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+  "name": "symbol_range_date_historical_price",
+  "request": {
+    "url": "/stock/twtr/chart/1m/20210210?chartByDay=true&token=TESTKEY",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": [
+      {
+        "close": 67.77,
+        "high": 69.25,
+        "low": 63.2,
+        "open": 65.8,
+        "symbol": "TWTR",
+        "volume": 73649183,
+        "id": "HISTORICAL_PRICES",
+        "key": "TWTR",
+        "subkey": "",
+        "date": "2021-02-10",
+        "updated": 1613015306000,
+        "changeOverTime": 0,
+        "marketChangeOverTime": 0,
+        "uOpen": 65.8,
+        "uClose": 67.77,
+        "uHigh": 69.25,
+        "uLow": 63.2,
+        "uVolume": 73649183,
+        "fOpen": 65.8,
+        "fClose": 67.77,
+        "fHigh": 69.25,
+        "fLow": 63.2,
+        "fVolume": 73649183,
+        "label": "Feb 10, 21",
+        "change": 0,
+        "changePercent": 0
+      }
+    ],
+    "headers" : {
+      "Server" : "nginx",
+      "Date" : "Thu, 08 Aug 2019 14:08:53 GMT",
+      "Content-Type" : "application/json; charset=utf-8",
+      "Connection" : "keep-alive",
+      "set-cookie" : "ctoken=958c0e17a3f542a2a13ef676b670326d; Domain=.iextrading.com; Path=/; Expires=Fri, 09 Aug 2019 02:08:53 GMT; Secure",
+      "Content-Security-Policy" : "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+      "X-Content-Security-Policy" : "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+      "Frame-Options" : "SAMEORIGIN",
+      "X-Frame-Options" : "SAMEORIGIN",
+      "X-Content-Type-Options" : "nosniff",
+      "Strict-Transport-Security" : "max-age=15768000",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Credentials" : "true",
+      "Access-Control-Allow-Methods" : "GET, OPTIONS",
+      "Access-Control-Allow-Headers" : "Origin, X-Requested-With, Content-Type, Accept"
+    }
+  },
+  "uuid" : "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+  "persistent" : true,
+  "insertionIndex" : 5
+}


### PR DESCRIPTION
**Goal:**
Create a new endpoint to FUSE that will allow users to query for historical prices.

**Inputs:**
Symbols (required): the stock ticker symbols that historical price data will be queried for
Date (not required, default = today): the date at which to get the historical prices for
Ranges (not required, default = 1 month): the range from the date to get the historical prices for

Note: if date and range are both present, date will supersede the range

**Function:**
IexRestController will serve as the endpoint for users of FUSE.

The method will call iexService which will have a new method getHistoricalPrices, this method will utilize the iexClient to fetch the data from the api.

The IexService getHistoricalPrices method will contain logic to call the correct method from the IexCloudClient depending on the amount of arguments passed in.

The IexCloudClient will be a new interface which will connect and make calls  to the Iex Cloud api. It will contain multiple methods which will be called by IexService.

The return value will be a list of IexHistoricalPrice objects which will contain the specified data for each day.

**Tests:**
The unit tests that will be conducted will check to see if the historicalData lines up with known dates and values and will work for varying inputs:

- Symbol, no date, no range
- Symbol, date, no range
- Symbol, no date, range
- No symbol input