### PR TITLE
Issue 3: historical price response storage

### DIFF
--- a/src/main/java/org/galatea/starter/domain/IexHistoricalPrice.java
+++ b/src/main/java/org/galatea/starter/domain/IexHistoricalPrice.java
@@ -1,10 +1,13 @@
 package org.galatea.starter.domain;
 
 import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
 @Builder
 public class IexHistoricalPrice {
   private BigDecimal close;

--- a/src/main/java/org/galatea/starter/domain/IexHistoricalPriceEntity.java
+++ b/src/main/java/org/galatea/starter/domain/IexHistoricalPriceEntity.java
@@ -1,0 +1,46 @@
+package org.galatea.starter.domain;
+
+import java.math.BigDecimal;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+@Data
+@Builder
+@IdClass(IexHistoricalPriceId.class)
+@Entity
+public class IexHistoricalPriceEntity {
+
+  @Id
+  @NonNull
+  private String symbol;
+
+  @Id
+  @NonNull
+  private String date;
+
+  @NonNull
+  private BigDecimal close;
+
+  @NonNull
+  private BigDecimal high;
+
+  @NonNull
+  private BigDecimal low;
+
+  @NonNull
+  private BigDecimal open;
+
+  @NonNull
+  private Integer volume;
+
+}

--- a/src/main/java/org/galatea/starter/domain/IexHistoricalPriceEntity.java
+++ b/src/main/java/org/galatea/starter/domain/IexHistoricalPriceEntity.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
+import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,6 +19,7 @@ import lombok.NonNull;
 @Builder
 @IdClass(IexHistoricalPriceId.class)
 @Entity
+@Table(name = "HISTORICAL_PRICE")
 public class IexHistoricalPriceEntity {
 
   @Id

--- a/src/main/java/org/galatea/starter/domain/IexHistoricalPriceEntity.java
+++ b/src/main/java/org/galatea/starter/domain/IexHistoricalPriceEntity.java
@@ -1,6 +1,7 @@
 package org.galatea.starter.domain;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
@@ -28,7 +29,7 @@ public class IexHistoricalPriceEntity {
 
   @Id
   @NonNull
-  private String date;
+  private LocalDate date;
 
   @NonNull
   private BigDecimal close;

--- a/src/main/java/org/galatea/starter/domain/IexHistoricalPriceId.java
+++ b/src/main/java/org/galatea/starter/domain/IexHistoricalPriceId.java
@@ -1,33 +1,17 @@
 package org.galatea.starter.domain;
 
 import java.io.Serializable;
-import java.util.Objects;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.NoArgsConstructor;
 
+@Data
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class IexHistoricalPriceId implements Serializable {
 
   private String symbol;
-  private String date;
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    IexHistoricalPriceId iexHistoricalPriceId = (IexHistoricalPriceId) o;
-    return symbol.equals(iexHistoricalPriceId.symbol) && date.equals(iexHistoricalPriceId.date);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(symbol, date);
-  }
-
+  private LocalDate date;
 }

--- a/src/main/java/org/galatea/starter/domain/IexHistoricalPriceId.java
+++ b/src/main/java/org/galatea/starter/domain/IexHistoricalPriceId.java
@@ -1,0 +1,33 @@
+package org.galatea.starter.domain;
+
+import java.io.Serializable;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+public class IexHistoricalPriceId implements Serializable {
+
+  private String symbol;
+  private String date;
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    IexHistoricalPriceId iexHistoricalPriceId = (IexHistoricalPriceId) o;
+    return symbol.equals(iexHistoricalPriceId.symbol) && date.equals(iexHistoricalPriceId.date);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(symbol, date);
+  }
+
+}

--- a/src/main/java/org/galatea/starter/domain/rpsy/IexHistoricalPriceRpsy.java
+++ b/src/main/java/org/galatea/starter/domain/rpsy/IexHistoricalPriceRpsy.java
@@ -1,0 +1,12 @@
+package org.galatea.starter.domain.rpsy;
+
+import org.galatea.starter.domain.IexHistoricalPriceEntity;
+import org.galatea.starter.domain.IexHistoricalPriceId;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IexHistoricalPriceRpsy extends CrudRepository<
+    IexHistoricalPriceEntity,
+    IexHistoricalPriceId> {
+}

--- a/src/main/java/org/galatea/starter/domain/rpsy/IexHistoricalPriceRpsy.java
+++ b/src/main/java/org/galatea/starter/domain/rpsy/IexHistoricalPriceRpsy.java
@@ -1,5 +1,7 @@
 package org.galatea.starter.domain.rpsy;
 
+import java.time.LocalDate;
+import java.util.List;
 import org.galatea.starter.domain.IexHistoricalPriceEntity;
 import org.galatea.starter.domain.IexHistoricalPriceId;
 import org.springframework.data.repository.CrudRepository;
@@ -9,4 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface IexHistoricalPriceRpsy extends CrudRepository<
     IexHistoricalPriceEntity,
     IexHistoricalPriceId> {
+
+  List<IexHistoricalPriceEntity> findBySymbolIgnoreCaseAndDateBetween(String symbol, LocalDate endDate, LocalDate startDate);
 }

--- a/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
+++ b/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
@@ -54,7 +54,7 @@ public class IexRestController {
    * Get the historical price for each of the symbols passed in.
    *
    * @param symbol list of symbols to get the historical price for.
-   * @param date list of days to get the historical price for.
+   * @param date list of days to get the historical price for in the format YYYY-MM-DD.
    * @param range range of time from the specified date to get data for.
    * @return a list of daily prices for date and range specified for the particular symbol.
    */

--- a/src/main/java/org/galatea/starter/service/IexCloudClient.java
+++ b/src/main/java/org/galatea/starter/service/IexCloudClient.java
@@ -14,32 +14,21 @@ import org.springframework.web.bind.annotation.PathVariable;
 public interface IexCloudClient {
 
   /**
-   * Get the historical price data for the symbol passed in.
-   * See https://iexcloud.io/docs/api/#historical-prices.
-   *
-   * @param symbol stock symbols to historical prices for.
-   * @return a list of daily IexHistoricalPrices for the past month for the symbol specified.
-   */
-  @GetMapping("/stock/{symbol}/chart?token=${spring.rest.iexToken}")
-  List<IexHistoricalPrice> getHistoricalPricesSymbol(
-      @PathVariable(value = "symbol") String symbol);
-
-  /**
-   * Get the historical price data for each symbol passed in for each date and range passed in.
-   * See https://iexcloud.io/docs/api/#historical-prices.
+   * Get the historical price data for each symbol passed in for each date and range passed in. See
+   * https://iexcloud.io/docs/api/#historical-prices.
    *
    * @param symbol stock symbols to historical price for.
-   * @param date date to get the historical data for
+   * @param date date to get the historical data for in YYYYMMDD format.
    * @return a list containing a IexHistoricalPrice for the specified date.
    */
-  @GetMapping("/stock/{symbol}/chart/date/{date}?chartByDate=true&token=${spring.rest.iexToken}")
+  @GetMapping("/stock/{symbol}/chart/date/{date}?chartByDay=true&token=${spring.rest.iexToken}")
   List<IexHistoricalPrice> getHistoricalPricesDate(
       @PathVariable(value = "symbol") String symbol,
       @PathVariable(value = "date") String date);
 
   /**
-   * Get the historical price data for each symbol passed in for each date and range passed in.
-   * See https://iexcloud.io/docs/api/#historical-prices.
+   * Get the historical price data for each symbol passed in for each date and range passed in. See
+   * https://iexcloud.io/docs/api/#historical-prices.
    *
    * @param symbol stock symbols to historical prices for.
    * @param range range of dates from date to get historical prices for.
@@ -49,21 +38,4 @@ public interface IexCloudClient {
   List<IexHistoricalPrice> getHistoricalPricesRange(
       @PathVariable(value = "symbol") String symbol,
       @PathVariable(value = "range") String range);
-
-  /**
-   * Get the historical price data for each symbol passed in for each date and range passed in.
-   * See https://iexcloud.io/docs/api/#historical-prices.
-   * Note: if date is specified it will nullify the range input and will only return
-   * the price of the exact day.
-   *
-   * @param symbol stock symbols to historical prices for.
-   * @param date date to begin getting historical prices for.
-   * @param range range of dates from date to get historical prices for.
-   * @return a list of IexHistoricalPrice for the specified date and symbol.
-   */
-  @GetMapping("/stock/{symbol}/chart/{range}/{date}?chartByDay=true&token=${spring.rest.iexToken}")
-  List<IexHistoricalPrice> getHistoricalPrices(
-      @PathVariable(value = "symbol") String symbol,
-      @PathVariable(value = "range") String range,
-      @PathVariable(value = "date") String date);
 }

--- a/src/main/java/org/galatea/starter/service/IexService.java
+++ b/src/main/java/org/galatea/starter/service/IexService.java
@@ -1,6 +1,11 @@
 package org.galatea.starter.service;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +15,7 @@ import org.galatea.starter.domain.IexHistoricalPriceEntity;
 import org.galatea.starter.domain.IexLastTradedPrice;
 import org.galatea.starter.domain.IexSymbol;
 import org.galatea.starter.domain.rpsy.IexHistoricalPriceRpsy;
+import org.galatea.starter.utils.DateChecker;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
@@ -63,19 +69,229 @@ public class IexService {
       final String range,
       final String date) {
     List<IexHistoricalPrice> historicalPriceList;
-    if (date == null && range == null) {
-      historicalPriceList = iexCloudClient.getHistoricalPricesSymbol(symbol);
-    } else if (range == null) {
-      historicalPriceList = iexCloudClient.getHistoricalPricesDate(symbol, date);
-    } else if (date == null) {
-      historicalPriceList = iexCloudClient.getHistoricalPricesRange(symbol, range);
+    HashSet<LocalDate> tradingDates;
+    String startDate = date == null
+        ? getStartDate()
+        : date;
+    String endDate = date == null
+        ? getEndDate(startDate, range)
+        : LocalDate.parse(date).minusDays(1).toString();
+
+    //Fetch a list  of prices between the startDate and endDate.
+    log.info("Symbol: " + symbol + " startDate: " + startDate + " endDate: " + endDate);
+    historicalPriceList = fetchHistoricalPricesDB(symbol, endDate, startDate);
+    log.info("Historical Prices retrieved from database: " + historicalPriceList.toString());
+
+    //Get a list of all the trading dates in the range provided.
+    tradingDates = getTradingDates(startDate, endDate);
+    log.info("Trading Dates for specified range are: " + tradingDates.toString());
+
+    //Compare the two datasets to find the missing dates of data.
+    HashSet<LocalDate> missingDates = getMissingDates(historicalPriceList, tradingDates);
+    log.info("Missing dates are: " + missingDates.toString());
+
+    // If missingDates is empty, there are no missing dates, return the list from the database.
+    if(missingDates.isEmpty()){
+      log.info("There are no missing dates");
+      return historicalPriceList;
     } else {
-      historicalPriceList = iexCloudClient.getHistoricalPrices(symbol, range, date);
+      log.info("There are missing dates, beginning formatting of IEX request");
+      int missingPriceAmount = missingDates.size();
+      LocalDate furthestMissingPrice = getFurthestMissingDate(missingDates);
+      return calcBestQuery(symbol, missingPriceAmount, furthestMissingPrice, startDate);
+    }
+  }
+
+  /**
+   * Get the start date for the query based on the current local time, minus one day (because todays
+   * trading may not have finished).
+   * @return a String of the local date in the format YYYY-MM-DD.
+   */
+  public String getStartDate() {
+    //Using LocalDate.now() here can cause problems down the line
+    return LocalDate.now().minusDays(1).format(DateTimeFormatter.ISO_DATE);
+  }
+
+  /**
+   * Calculates the end date based on the startDate and the range provided. Will also handle
+   * certain edge cases such as the default range, and other input types.
+   * @param startDate the startDate for the query.
+   * @param range the range that is required to find the end date.
+   * @return a LocalDate for the end date that was calculated.
+   */
+  public String getEndDate(final String startDate, final String range) {
+    //Adjust range for edge scenarios
+    String adjustedRange = range;
+    if (range == null) {
+      adjustedRange = "1m";
+    } else if (range.equals("ytd")) {
+      adjustedRange = "1y";
+    } else if (range.equals("max")) {
+      adjustedRange = "5y";
     }
 
-    addHistoricalPricesToDB(historicalPriceList);
+    String[] rangeSplit = adjustedRange.split("(?<=\\d)(?=\\D)");
+    int dateVal = Integer.parseInt(rangeSplit[0]);
+    String dateType = rangeSplit[1];
 
-    return historicalPriceList;
+    String endDate;
+    switch (dateType) {
+      case "d":
+        endDate = LocalDate.now().minusDays(dateVal + 1).format(DateTimeFormatter.ISO_DATE);
+        break;
+      case "m":
+        endDate = LocalDate.now().minusMonths(dateVal).format(DateTimeFormatter.ISO_DATE);
+        break;
+      case "y":
+        endDate = LocalDate.now().minusYears(dateVal).format(DateTimeFormatter.ISO_DATE);
+        break;
+      default:
+        log.error("Error: invalid dateType: " + dateType);
+        endDate = startDate;
+        break;
+    }
+    return endDate;
+  }
+
+  /**
+   * Attempt to fetch historical prices for the required range from the database.
+   * @param symbol the symbol for the stock that is being queried for.
+   * @param startDate the start date of the range that is required.
+   * @param endDate the end date of the range that is required.
+   * @return returns a List of all the prices that are in the database for the range selected.
+   */
+  public List<IexHistoricalPrice> fetchHistoricalPricesDB(
+      final String symbol,
+      final String startDate,
+      final String endDate) {
+    LocalDate start = LocalDate.parse(startDate);
+    LocalDate end = LocalDate.parse(endDate);
+
+    List<IexHistoricalPriceEntity> dbEntityResult;
+    dbEntityResult = historicalPriceRspy.findBySymbolIgnoreCaseAndDateBetween(symbol, start, end);
+
+    List<IexHistoricalPrice> dbAdjustedResult = new ArrayList<IexHistoricalPrice>();
+    for (IexHistoricalPriceEntity entity : dbEntityResult) {
+      IexHistoricalPrice price = new IexHistoricalPrice(
+          entity.getClose(),
+          entity.getHigh(),
+          entity.getLow(),
+          entity.getOpen(),
+          entity.getSymbol(),
+          entity.getVolume(),
+          entity.getDate().toString()
+      );
+      dbAdjustedResult.add(price);
+    }
+    return dbAdjustedResult;
+  }
+
+  /**
+   * Get all the valid trading dates for the range provided. This will remove exchange holidays
+   * and weekends as there will be no data on those days.
+   * @param startDate is the first day in the range of the query requested.
+   * @param endDate is the last day in the range of the query requested.
+   * @return a HashSet of all the trading days between the two ranges.
+   */
+  public HashSet<LocalDate> getTradingDates(final String startDate, final String endDate) {
+    LocalDate start = LocalDate.parse(startDate);
+    LocalDate end = LocalDate.parse(endDate);
+    HashSet<LocalDate> allDates = new HashSet<>();
+    log.info("Getting trading dates for specified range");
+    while (start.isAfter(end)) {
+      log.info("Checking if trading day: " + start);
+      if(DateChecker.isTradingDay(start)) {
+        log.info("Is a trading day: " + start);
+        allDates.add(start);
+      }
+      start = start.minusDays(1);
+    }
+    return allDates;
+  }
+
+  /**
+   * Compares the dates stored in the database to the dates that are needed. And calculates the
+   * difference between these two.
+   * @param pricesInDB a List of all the IexHistoricalPrice objects in the database within the
+   * specified date range.
+   * @param datesNeeded a HashSet of LocalDate of all the dates that are required by  the query.
+   * @return a HashSet of LocalDates containing the dates that are not in the database but are
+   * required for the query.
+   */
+  public HashSet<LocalDate> getMissingDates(
+      final List<IexHistoricalPrice> pricesInDB,
+      HashSet<LocalDate> datesNeeded) {
+    for ( IexHistoricalPrice pricePoint : pricesInDB) {
+      LocalDate date = LocalDate.parse(pricePoint.getDate());
+      datesNeeded.remove(date);
+    }
+    return datesNeeded;
+  }
+
+  /**
+   * Finds the furthest missing date from the current day.
+   * @param missingDates is a set of dates that are required for the query, that are trading days,
+   * that are not available in the database.
+   * @return returns the LocalDate of the date furthest back in time
+   */
+  public LocalDate getFurthestMissingDate(final HashSet<LocalDate> missingDates) {
+    LocalDate furthest = null;
+    for ( LocalDate date : missingDates ) {
+      if(furthest == null || date.isBefore(furthest)){
+        furthest = date;
+      }
+    }
+    return furthest;
+  }
+
+  /**
+   * Calculates the best query that will minimise the amount of repeat data fetched from the IEX api.
+   * Note: this method can be further optimised if the cost weights of different queries can be
+   * identified.
+   * @param symbol of the stock being queried for.
+   * @param missingPriceAmount is the amount of missing price dates that exist.
+   * @param furthestMissingDate is the furthest missing date.
+   * @param startDate the start date of the range query.
+   * @return returns a List of IexHistoricalPrices that have been fetched from the Iex API.
+   */
+  public List<IexHistoricalPrice> calcBestQuery(
+      final String symbol,
+      int missingPriceAmount,
+      LocalDate furthestMissingDate,
+      String startDate) {
+    if(missingPriceAmount == 1) {
+      log.info("Only one day is missing, creating date query");
+      return fetchHistoricalPrices(symbol, null, furthestMissingDate.toString());
+    } else {
+      LocalDate start = LocalDate.parse(startDate);
+      long daysBetween = ChronoUnit.DAYS.between(start, furthestMissingDate.minusDays(1));
+      String bestRange = Math.abs(daysBetween) + "d";
+      log.info("Range of dates are missing, range query is: " + bestRange);
+      return fetchHistoricalPrices(symbol, bestRange, null);
+    }
+  }
+
+  /**
+   * Get the historical price for a specified Symbol for a certain range starting at date.
+   * @param symbol the symbol to get historical prices for.
+   * @param date the date to begin getting historical prices at.
+   * @param range the range to get historical prices at.
+   * @return a list of historical prices for the specified symbol and time frame.
+   */
+  public List<IexHistoricalPrice> fetchHistoricalPrices(
+      final String symbol,
+      final String range,
+      final String date) {
+    List<IexHistoricalPrice> fetchedHistoricalPrices;
+    if (date == null) {
+      fetchedHistoricalPrices = iexCloudClient.getHistoricalPricesRange(symbol, range);
+    } else {
+      String formattedDate = date.replace("-", "");
+      log.info("Formatted Date is: " + formattedDate);
+      fetchedHistoricalPrices = iexCloudClient.getHistoricalPricesDate(symbol, formattedDate);
+    }
+    addHistoricalPricesToDB(fetchedHistoricalPrices);
+    return fetchedHistoricalPrices;
   }
 
   /**
@@ -83,17 +299,20 @@ public class IexService {
    * @param historicalPriceList a list of Historical Prices fetched from the IEX API
    */
   public void addHistoricalPricesToDB(final List<IexHistoricalPrice> historicalPriceList) {
+    List<IexHistoricalPriceEntity> priceEntityList = new ArrayList<IexHistoricalPriceEntity>();
     for (IexHistoricalPrice price : historicalPriceList) {
       IexHistoricalPriceEntity entity = new IexHistoricalPriceEntity(
           price.getSymbol(),
-          price.getDate(),
+          LocalDate.parse(price.getDate()),
           price.getClose(),
           price.getHigh(),
           price.getLow(),
           price.getOpen(),
           price.getVolume());
-      historicalPriceRspy.save(entity);
+      priceEntityList.add(entity);
       log.info("Adding to database: " + entity.toString());
     }
+    log.info("Saving all historical prices to database");
+    historicalPriceRspy.saveAll(priceEntityList);
   }
 }

--- a/src/main/java/org/galatea/starter/utils/DateChecker.java
+++ b/src/main/java/org/galatea/starter/utils/DateChecker.java
@@ -2,84 +2,81 @@ package org.galatea.starter.utils;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-public class DateChecker {
-  static HashSet<String> holidayDates;
-
-  public DateChecker() {
-    holidayDates = new HashSet<>(Arrays.asList(
-        "2021-01-01",
-        "2021-01-18",
-        "2021-02-15",
-        "2021-04-2",
-        "2021-05-31",
-        "2021-07-04",
-        "2021-09-06",
-        "2021-11-25",
-        "2021-12-24",
-        "2020-01-01",
-        "2020-01-20",
-        "2020-02-17",
-        "2020-04-10",
-        "2020-05-25",
-        "2020-07-04",
-        "2020-09-07",
-        "2020-11-26",
-        "2020-12-25",
-        "2019-01-01",
-        "2019-01-21",
-        "2019-02-18",
-        "2019-03-19",
-        "2019-04-27",
-        "2019-07-04",
-        "2019-09-02",
-        "2019-11-28",
-        "2019-12-25",
-        "2018-01-01",
-        "2018-01-15",
-        "2018-02-19",
-        "2018-03-30",
-        "2018-04-28",
-        "2018-07-04",
-        "2018-09-03",
-        "2018-11-22",
-        "2018-12-25",
-        "2017-01-02",
-        "2017-01-16",
-        "2017-02-20",
-        "2017-03-14",
-        "2017-04-29",
-        "2017-07-04",
-        "2017-09-04",
-        "2017-11-23",
-        "2017-12-25",
-        "2016-01-01",
-        "2016-01-18",
-        "2016-02-15",
-        "2016-03-25",
-        "2016-04-30",
-        "2016-07-04",
-        "2016-09-05",
-        "2016-11-24",
-        "2016-12-26",
-        "2015-01-01",
-        "2015-01-19",
-        "2015-02-16",
-        "2015-03-03",
-        "2015-04-25",
-        "2015-07-03",
-        "2015-09-07",
-        "2015-11-26",
-        "2015-12-25"));
-  }
+public final class DateChecker {
+  static Set<String> holidayDates = Stream.of("2021-01-01",
+      "2021-01-18",
+      "2021-02-15",
+      "2021-04-2",
+      "2021-05-31",
+      "2021-07-04",
+      "2021-09-06",
+      "2021-11-25",
+      "2021-12-24",
+      "2020-01-01",
+      "2020-01-20",
+      "2020-02-17",
+      "2020-04-10",
+      "2020-05-25",
+      "2020-07-04",
+      "2020-09-07",
+      "2020-11-26",
+      "2020-12-25",
+      "2019-01-01",
+      "2019-01-21",
+      "2019-02-18",
+      "2019-03-19",
+      "2019-04-27",
+      "2019-07-04",
+      "2019-09-02",
+      "2019-11-28",
+      "2019-12-25",
+      "2018-01-01",
+      "2018-01-15",
+      "2018-02-19",
+      "2018-03-30",
+      "2018-04-28",
+      "2018-07-04",
+      "2018-09-03",
+      "2018-11-22",
+      "2018-12-25",
+      "2017-01-02",
+      "2017-01-16",
+      "2017-02-20",
+      "2017-03-14",
+      "2017-04-29",
+      "2017-07-04",
+      "2017-09-04",
+      "2017-11-23",
+      "2017-12-25",
+      "2016-01-01",
+      "2016-01-18",
+      "2016-02-15",
+      "2016-03-25",
+      "2016-04-30",
+      "2016-07-04",
+      "2016-09-05",
+      "2016-11-24",
+      "2016-12-26",
+      "2015-01-01",
+      "2015-01-19",
+      "2015-02-16",
+      "2015-03-03",
+      "2015-04-25",
+      "2015-07-03",
+      "2015-09-07",
+      "2015-11-26",
+      "2015-12-25")
+      .collect(Collectors.toUnmodifiableSet());
 
   /**
    * Returns true if the day is not a exchange holiday or a weekend
    *
    */
-  public static boolean isTradingDay(final String day) {
+  public static boolean isTradingDay(final LocalDate day) {
     return !(isExchangeHoliday(day) || isWeekend(day));
   }
 
@@ -88,9 +85,8 @@ public class DateChecker {
    * Checks the date to see if it is a Weekend, returns true if it is, false otherwise.
    *
    */
-  public static boolean isWeekend(final String day) {
-    LocalDate date = LocalDate.parse(day);
-    DayOfWeek dow = date.getDayOfWeek();
+  public static boolean isWeekend(final LocalDate day) {
+    DayOfWeek dow = day.getDayOfWeek();
     return dow.getValue() == 6 || dow.getValue() == 7;
   }
 
@@ -98,7 +94,7 @@ public class DateChecker {
    * Checks if the date provided is in the set of trading holidays.
    *
    */
-  public static boolean isExchangeHoliday(final String day) {
-    return holidayDates.contains(day);
+  public static boolean isExchangeHoliday(final LocalDate day) {
+    return holidayDates.contains(day.toString());
   }
 }

--- a/src/main/java/org/galatea/starter/utils/DateChecker.java
+++ b/src/main/java/org/galatea/starter/utils/DateChecker.java
@@ -1,0 +1,104 @@
+package org.galatea.starter.utils;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.HashSet;
+
+public class DateChecker {
+  static HashSet<String> holidayDates;
+
+  public DateChecker() {
+    holidayDates = new HashSet<>(Arrays.asList(
+        "2021-01-01",
+        "2021-01-18",
+        "2021-02-15",
+        "2021-04-2",
+        "2021-05-31",
+        "2021-07-04",
+        "2021-09-06",
+        "2021-11-25",
+        "2021-12-24",
+        "2020-01-01",
+        "2020-01-20",
+        "2020-02-17",
+        "2020-04-10",
+        "2020-05-25",
+        "2020-07-04",
+        "2020-09-07",
+        "2020-11-26",
+        "2020-12-25",
+        "2019-01-01",
+        "2019-01-21",
+        "2019-02-18",
+        "2019-03-19",
+        "2019-04-27",
+        "2019-07-04",
+        "2019-09-02",
+        "2019-11-28",
+        "2019-12-25",
+        "2018-01-01",
+        "2018-01-15",
+        "2018-02-19",
+        "2018-03-30",
+        "2018-04-28",
+        "2018-07-04",
+        "2018-09-03",
+        "2018-11-22",
+        "2018-12-25",
+        "2017-01-02",
+        "2017-01-16",
+        "2017-02-20",
+        "2017-03-14",
+        "2017-04-29",
+        "2017-07-04",
+        "2017-09-04",
+        "2017-11-23",
+        "2017-12-25",
+        "2016-01-01",
+        "2016-01-18",
+        "2016-02-15",
+        "2016-03-25",
+        "2016-04-30",
+        "2016-07-04",
+        "2016-09-05",
+        "2016-11-24",
+        "2016-12-26",
+        "2015-01-01",
+        "2015-01-19",
+        "2015-02-16",
+        "2015-03-03",
+        "2015-04-25",
+        "2015-07-03",
+        "2015-09-07",
+        "2015-11-26",
+        "2015-12-25"));
+  }
+
+  /**
+   * Returns true if the day is not a exchange holiday or a weekend
+   *
+   */
+  public static boolean isTradingDay(final String day) {
+    return !(isExchangeHoliday(day) || isWeekend(day));
+  }
+
+
+  /**
+   * Checks the date to see if it is a Weekend, returns true if it is, false otherwise.
+   *
+   */
+  public static boolean isWeekend(final String day) {
+    LocalDate date = LocalDate.parse(day);
+    DayOfWeek dow = date.getDayOfWeek();
+    return dow.getValue() == 6 || dow.getValue() == 7;
+  }
+
+  /**
+   * Checks if the date provided is in the set of trading holidays.
+   *
+   */
+  public static boolean isExchangeHoliday(final String day) {
+    return holidayDates.contains(day);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,12 +9,18 @@ spring:
       # in case you want to use H2 with a file persistence or as a service
       # reference http://www.h2database.com/html/cheatSheet.html and
       # http://www.h2database.com/html/tutorial.html#using_server
-      url: jdbc:h2:mem:testtest
+      url: jdbc:h2:mem:testdb
       driver-class-name: org.h2.Driver
+      username: sa
+      password:
    jpa:
       hibernate:
          ddl-auto: update
       database-platform: org.hibernate.dialect.MySQL5Dialect
+   h2:
+      console:
+        enabled: true
+        path: /h2
 
 mvc:
    settleMissionPath: /settlementEngine
@@ -54,6 +60,9 @@ spring:
 ---
 # Dev properties go here
 spring:
+   jpa:
+      show-sql: true
+      properties.hibernate.format_sql: true
    profiles: dev
    datasource:
       username: sa


### PR DESCRIPTION
### Issue 3: Add Response Storage to Historical Price Endpoint
The Historical Prices endpoint currently forwards calls to the Iex Historical Prices API every time, even if the same data is requested twice. We should speed up subsequent calls to the FUSE API by storing previously requested Historical Prices, serving them to the caller without making an external call to the Iex API.